### PR TITLE
Fix wasm builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT/Apache-2.0"
 tokio = ["dep:tokio"]
 
 [dependencies]
-async-channel = "1"
+async-channel = "2"
 bevy_app = "0.14"
 bevy_ecs = "0.14"
 bevy_tasks = { version = "0.14", features = ["multi_threaded"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,7 @@ impl bevy_app::Plugin for Plugin {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 pub type AsyncReturn<Output> = pin::Pin<Box<dyn future::Future<Output = Output> + Send + 'static>>;
-#[cfg(target_arch = "wasm32")]
-pub type AsyncReturn<Output> = pin::Pin<Box<dyn future::Future<Output = Output> + 'static>>;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum JobType {


### PR DESCRIPTION
Fix the following error when building with wasm 

```shell
> cargo build --target=wasm32-unknown-unknown --features tokio

   Compiling bevy_jobs v0.1.0 (/Users/sytherax/personal/bevy_jobs)
error: future cannot be sent between threads safely
   --> src/lib.rs:78:31
    |
78  |             JobType::Tokio => spawn_tokio_task(task),
    |                               ^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
    |
    = help: the trait `std::marker::Send` is not implemented for `dyn Future<Output = <Self as Job>::Outcome>`
note: future is not `Send` as it awaits another future which is not `Send`
   --> src/lib.rs:57:27
    |
57  |             let outcome = self.perform(Context { progress_tx }).await;
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ await occurs here on type `Pin<Box<dyn Future<Output = <Self as Job>::Outcome>>>`, which is not `Send`
note: required by a bound in `spawn_tokio_task`
   --> src/lib.rs:176:92
    |
176 | fn spawn_tokio_task<Output: Send + 'static>(future: impl future::Future<Output = Output> + Send +'static) {
    |                                                                                            ^^^^ required by this bound in `spawn_tokio_task`

error: could not compile `bevy_jobs` (lib) due to 1 previous error
```